### PR TITLE
Add keyboard navigation for menus

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1449,6 +1449,25 @@ let startButton: HTMLButtonElement, restartButton: HTMLButtonElement, pauseResta
 // Мини-карта
 let minimapCanvas: HTMLCanvasElement;
 let _prevState: GameStateType = gameStateAtom();
+let menuButtons: HTMLButtonElement[] = [];
+let menuIndex = 0;
+
+function updateMenuSelection() {
+    menuButtons.forEach((btn, idx) => {
+        if (idx === menuIndex) {
+            btn.classList.add('selected');
+            btn.focus({ preventScroll: true });
+        } else {
+            btn.classList.remove('selected');
+        }
+    });
+}
+
+function setMenuButtons(buttons: HTMLButtonElement[]) {
+    menuButtons = buttons;
+    menuIndex = 0;
+    updateMenuSelection();
+}
 
 document.addEventListener('DOMContentLoaded', () => {
     console.log('🔧 DOM Content Loaded - Initializing UI elements...');
@@ -1516,6 +1535,8 @@ document.addEventListener('DOMContentLoaded', () => {
         gameStateAtom.setMenu();
     });
 
+    setMenuButtons([startButton]);
+
     // Инициализируем иконку камеры
     updateCameraModeIndicator();
 
@@ -1576,6 +1597,19 @@ effect(() => {
     if (difficultyDisplay) {
         const shouldShowDifficulty = isPlaying || isPaused || isGameOver;
         difficultyDisplay.classList.toggle('hidden', !shouldShowDifficulty);
+    }
+
+    if (state !== _prevState) {
+        if (isMenu) {
+            setMenuButtons([startButton]);
+        } else if (isPaused) {
+            setMenuButtons([resumeButton, pauseRestartButton, pauseMenuButton]);
+        } else if (isGameOver) {
+            setMenuButtons([restartButton, mainMenuButton]);
+        } else {
+            menuButtons.forEach(btn => btn.classList.remove('selected'));
+            menuButtons = [];
+        }
     }
 
     // Управление фоном сцены
@@ -1670,25 +1704,36 @@ effect(() => {
 // Controls
 window.addEventListener('keydown', (event) => {
     const state = gameStateAtom();
-    if (state === GameState.MENU && (event.code === 'Enter' || event.code === 'Space')) {
+
+    if (state === GameState.PAUSED && event.code === 'Escape') {
         event.preventDefault();
         gameStateAtom.setPlaying();
+        return;
     }
 
-    if (state === GameState.GAME_OVER) {
-        if (event.code === 'Enter' || event.code === 'Space') {
-            event.preventDefault();
-            gameStateAtom.setPlaying();
-        } else if (event.code === 'Escape') {
-            event.preventDefault();
-            gameStateAtom.setMenu();
-        }
+    if (state === GameState.GAME_OVER && event.code === 'Escape') {
+        event.preventDefault();
+        gameStateAtom.setMenu();
+        return;
     }
 
-    if (state === GameState.PAUSED) {
-        if (event.code === 'Escape' || event.code === 'Enter' || event.code === 'Space') {
-            event.preventDefault();
-            gameStateAtom.setPlaying();
+    if (state === GameState.MENU || state === GameState.PAUSED || state === GameState.GAME_OVER) {
+        if (menuButtons.length > 0) {
+            if (event.code === 'ArrowUp') {
+                event.preventDefault();
+                menuIndex = (menuIndex - 1 + menuButtons.length) % menuButtons.length;
+                updateMenuSelection();
+                return;
+            } else if (event.code === 'ArrowDown') {
+                event.preventDefault();
+                menuIndex = (menuIndex + 1) % menuButtons.length;
+                updateMenuSelection();
+                return;
+            } else if (event.code === 'Enter' || event.code === 'Space') {
+                event.preventDefault();
+                menuButtons[menuIndex].click();
+                return;
+            }
         }
     }
 

--- a/src/style.css
+++ b/src/style.css
@@ -262,6 +262,15 @@ body {
     0 0 30px rgba(255, 107, 53, 0.4);
 }
 
+.game-button.selected {
+  background: linear-gradient(45deg, #ff9c42, #ffc370);
+  transform: translateY(-2px);
+  box-shadow:
+    0 0 10px #00ffff,
+    0 0 20px #00ffff,
+    0 7px 20px rgba(255, 107, 53, 0.6);
+}
+
 .game-button:active {
   transform: translateY(0);
 }


### PR DESCRIPTION
## Summary
- allow moving between menu items with arrow keys
- highlight selected menu button

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848da4a014483319d399c941fee4384