### PR TITLE
Disable lock delay timer indicator by default

### DIFF
--- a/src/game-logic.ts
+++ b/src/game-logic.ts
@@ -141,7 +141,7 @@ export const difficultyLevelAtom = atom(3).actions((target) => ({
     setLevel: (level: 2 | 3 | 4 | 5) => target.set(level)
 }));
 
-export const lockDelayTimerVisibleAtom = atom(true).actions((target) => ({
+export const lockDelayTimerVisibleAtom = atom(false).actions((target) => ({
     toggle: () => target.set(prev => !prev),
     show: () => target.set(true),
     hide: () => target.set(false)


### PR DESCRIPTION
## Summary
- make the lock delay timer indicator start hidden

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848fb87e94483318a8558c39a1c09ba