### PR TITLE
Fix rotation bindings

### DIFF
--- a/src/game-logic.ts
+++ b/src/game-logic.ts
@@ -369,11 +369,12 @@ export function rotateAroundZ(blocks: Block3D[]): Block3D[] {
 }
 
 export function rotateInViewPlane(blocks: Block3D[]): Block3D[] {
+    // Вращение в плоскости экрана относительно камеры (W)
     return rotateAroundY(blocks);
 }
 
 export function rotateVertical(blocks: Block3D[]): Block3D[] {
-    // Вращение в вертикальной плоскости относительно камеры (Q)
+    // Вращение в вертикальной плоскости относительно камеры (E)
     const rotationSteps = Math.round(fieldRotationAtom() / 90) % 4;
     switch (rotationSteps) {
         case 0: return rotateAroundZ(blocks);  // 0° - передняя стена видна, вращаем в плоскости XY
@@ -385,7 +386,7 @@ export function rotateVertical(blocks: Block3D[]): Block3D[] {
 }
 
 export function rotateSide(blocks: Block3D[]): Block3D[] {
-    // Вращение в боковой плоскости относительно камеры (E)
+    // Вращение в боковой плоскости относительно камеры (Q)
     const rotationSteps = Math.round(fieldRotationAtom() / 90) % 4;
     switch (rotationSteps) {
         case 0: return rotateAroundX(blocks);  // 0° - боковое вращение в плоскости YZ

--- a/src/main.ts
+++ b/src/main.ts
@@ -1806,7 +1806,7 @@ window.addEventListener('keydown', (event) => {
             case 'KeyQ': {
                 const piece = currentPieceAtom();
                 if (!piece) break;
-                const r = rotateInViewPlane(piece.blocks);
+                const r = rotateSide(piece.blocks);
                 if (canPlacePieceCompat(r, piece.position)) {
                     currentPieceAtom.rotate(r);
                     updateMinimap();
@@ -1818,7 +1818,7 @@ window.addEventListener('keydown', (event) => {
             case 'KeyW': {
                 const piece = currentPieceAtom();
                 if (!piece) break;
-                const r = rotateVertical(piece.blocks);
+                const r = rotateInViewPlane(piece.blocks);
                 if (canPlacePieceCompat(r, piece.position)) {
                     currentPieceAtom.rotate(r);
                     updateMinimap();
@@ -1830,7 +1830,7 @@ window.addEventListener('keydown', (event) => {
             case 'KeyE': {
                 const piece = currentPieceAtom();
                 if (!piece) break;
-                const r = rotateSide(piece.blocks);
+                const r = rotateVertical(piece.blocks);
                 if (canPlacePieceCompat(r, piece.position)) {
                     currentPieceAtom.rotate(r);
                     updateMinimap();


### PR DESCRIPTION
## Summary
- swap piece rotation bindings to match the help screen
- clarify comments about which key triggers which rotation

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848fef8ac148331ae524396b9389616