### PR TITLE
Add simple Tetris sounds with F9 toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,10 @@
                 <span class="key">F8</span>
                 <span class="description">Restart</span>
             </div>
+            <div class="control-item">
+                <span class="key">F9</span>
+                <span class="description">Sound On/Off</span>
+            </div>
         </div>
         <div class="controls-section controls-help-toggle">
             <div class="controls-title">HELP</div>

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -1,0 +1,39 @@
+import { atom } from '@reatom/core';
+
+export const soundEnabledAtom = atom(true).actions(target => ({
+    toggle: () => target.set(prev => !prev),
+    enable: () => target.set(true),
+    disable: () => target.set(false)
+}));
+
+let audioCtx: AudioContext | null = null;
+function getCtx(): AudioContext {
+    if (!audioCtx) {
+        const Ctx = window.AudioContext || (window as any).webkitAudioContext;
+        audioCtx = new Ctx();
+    }
+    return audioCtx!;
+}
+
+function playTone(freq: number, duration: number) {
+    if (!soundEnabledAtom()) return;
+    const ctx = getCtx();
+    ctx.resume();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = 'square';
+    osc.frequency.value = freq;
+    gain.gain.value = 0.1;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + duration);
+}
+
+export const sounds = {
+    move: () => playTone(600, 0.05),
+    rotate: () => playTone(800, 0.05),
+    drop: () => playTone(300, 0.1),
+    clear: () => playTone(1000, 0.15),
+    gameOver: () => playTone(200, 0.5)
+};

--- a/src/game-logic.ts
+++ b/src/game-logic.ts
@@ -7,6 +7,7 @@ import {
     DROP_INTERVAL
 } from './constants';
 import type { GameStateType } from './constants';
+import { sounds } from './audio';
 
 // Types
 
@@ -767,6 +768,7 @@ export const gameActions = {
 
         if (!canPlacePiece(piece.blocks, piece.position, field)) {
             gameStateAtom.setGameOver();
+            sounds.gameOver();
             return;
         }
 
@@ -794,6 +796,8 @@ export const gameActions = {
             if (dx !== 0 || dz !== 0) {
                 timersAtom.resetLockDelay();
             }
+
+            sounds.move();
 
             return true;
         }
@@ -825,6 +829,7 @@ export const gameActions = {
 
         if (canPlacePiece(rotatedBlocks, piece.position, field)) {
             currentPieceAtom.rotate(rotatedBlocks);
+            sounds.rotate();
             return true;
         }
 
@@ -844,6 +849,7 @@ export const gameActions = {
         }));
 
         gameFieldAtom.placePiece(piece);
+        sounds.drop();
 
         // Add placement score
         scoreAtom.add(10);
@@ -1014,6 +1020,7 @@ export const gameActions = {
 
             scoreAtom.add(lineScore + iterativeBonus);
             console.log(`💰 Итеративная очистка: ${totalLinesCleared} плоскостей, ${finalBlocksToDestroy.length} блоков. Очки: ${lineScore + iterativeBonus}`);
+            sounds.clear();
         }
     },
 
@@ -1148,6 +1155,7 @@ export const gameActions = {
 
             scoreAtom.add(lineScore + cubeBonus);
             console.log(`💰 Очищено: ${totalLinesCleared} плоскостей, ${cubeArrays.length} кубов. Очки: ${lineScore + cubeBonus}`);
+            sounds.clear();
         }
     },
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import {
 import { lockDelayTimerWidget } from './widgets/lock-delay-indicator.ts';
 import './models/lock-delay'; // Инициализируем модель lock delay
 import { lockDelayAtom } from './models/lock-delay';
+import { soundEnabledAtom } from './audio';
 import {
     GameState,
     FIELD_WIDTH,
@@ -1879,6 +1880,11 @@ window.addEventListener('keydown', (event) => {
             case 'F8':
                 event.preventDefault();
                 restartGame();
+                break;
+            case 'F9':
+                event.preventDefault();
+                soundEnabledAtom.toggle();
+                console.log(`\uD83C\uDFB5 Звук: ${soundEnabledAtom() ? 'включен' : 'выключен'}`);
                 break;
         }
     }


### PR DESCRIPTION
## Summary
- create audio module with basic oscillator beeps
- hook up sounds for movement, rotation, placement and line clears
- play game over sound when new piece can't spawn
- allow toggling sound with **F9** key
- document F9 shortcut in controls

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68492fd654988331a4686699e5ba0c96