### PR TITLE
Add rotation key hint above next piece

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,21 +149,27 @@
     </div>
     <div id="next-piece-container" class="next-piece-container hidden">
         <div class="next-piece-title">NEXT</div>
-        <svg class="rotation-hints" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-                <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-                    <path d="M 0 0 L 10 5 L 0 10 z" fill="#00ffff" />
-                </marker>
-            </defs>
-            <path d="M20 40 A20 20 0 0 1 60 40" marker-end="url(#arrow)" />
-            <text x="40" y="20">Q</text>
-            <path d="M120 40 A20 20 0 0 1 160 40" marker-end="url(#arrow)" />
-            <text x="140" y="20">W</text>
-            <path d="M220 40 A20 20 0 0 1 260 40" marker-end="url(#arrow)" />
-            <text x="240" y="20">E</text>
-        </svg>
         <canvas id="next-piece-canvas" class="next-piece-canvas"></canvas>
     </div>
+    <svg id="rotation-hints" class="rotation-hints hidden" viewBox="0 0 240 60" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+            <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                <path d="M 0 0 L 10 5 L 0 10 z" fill="#00ffff" />
+            </marker>
+        </defs>
+        <g class="hint hint-q">
+            <path d="M10 30 A20 20 0 0 1 50 30" marker-end="url(#arrow)" />
+            <text x="30" y="55">Q</text>
+        </g>
+        <g class="hint hint-w" transform="translate(80,0)">
+            <path d="M10 30 A20 20 0 0 1 50 30" marker-end="url(#arrow)" />
+            <text x="30" y="55">W</text>
+        </g>
+        <g class="hint hint-e" transform="translate(160,0)">
+            <path d="M10 30 A20 20 0 0 1 50 30" marker-end="url(#arrow)" />
+            <text x="30" y="55">E</text>
+        </g>
+    </svg>
 </div>
 <script type="module" src="/src/main.ts"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -151,25 +151,12 @@
         <div class="next-piece-title">NEXT</div>
         <canvas id="next-piece-canvas" class="next-piece-canvas"></canvas>
     </div>
-    <svg id="rotation-hints" class="rotation-hints hidden" viewBox="0 0 240 60" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-            <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-                <path d="M 0 0 L 10 5 L 0 10 z" fill="#00ffff" />
-            </marker>
-        </defs>
-        <g class="hint hint-q">
-            <path d="M10 30 A20 20 0 0 1 50 30" marker-end="url(#arrow)" />
-            <text x="30" y="55">Q</text>
-        </g>
-        <g class="hint hint-w" transform="translate(80,0)">
-            <path d="M10 30 A20 20 0 0 1 50 30" marker-end="url(#arrow)" />
-            <text x="30" y="55">W</text>
-        </g>
-        <g class="hint hint-e" transform="translate(160,0)">
-            <path d="M10 30 A20 20 0 0 1 50 30" marker-end="url(#arrow)" />
-            <text x="30" y="55">E</text>
-        </g>
-    </svg>
+    <div id="rotation-hints" class="rotation-hints-container hidden">
+        <canvas id="rotation-hints-canvas" class="rotation-hints-canvas"></canvas>
+        <div class="rotation-label label-q">Q</div>
+        <div class="rotation-label label-w">W</div>
+        <div class="rotation-label label-e">E</div>
+    </div>
 </div>
 <script type="module" src="/src/main.ts"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -149,6 +149,19 @@
     </div>
     <div id="next-piece-container" class="next-piece-container hidden">
         <div class="next-piece-title">NEXT</div>
+        <svg class="rotation-hints" viewBox="0 0 300 60" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                    <path d="M 0 0 L 10 5 L 0 10 z" fill="#00ffff" />
+                </marker>
+            </defs>
+            <path d="M20 40 A20 20 0 0 1 60 40" marker-end="url(#arrow)" />
+            <text x="40" y="20">Q</text>
+            <path d="M120 40 A20 20 0 0 1 160 40" marker-end="url(#arrow)" />
+            <text x="140" y="20">W</text>
+            <path d="M220 40 A20 20 0 0 1 260 40" marker-end="url(#arrow)" />
+            <text x="240" y="20">E</text>
+        </svg>
         <canvas id="next-piece-canvas" class="next-piece-canvas"></canvas>
     </div>
 </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1455,7 +1455,7 @@ function updateNextPiecePreview() {
 // Запуск анимации вращения миникарты уже не нужен - анимация происходит синхронно в animateRotation()
 
 // UI Elements
-let startButton: HTMLButtonElement, restartButton: HTMLButtonElement, pauseRestartButton: HTMLButtonElement, mainMenuButton: HTMLButtonElement, resumeButton: HTMLButtonElement, pauseMenuButton: HTMLButtonElement, startMenu: HTMLDivElement, pauseMenu: HTMLDivElement, scoreDisplay: HTMLDivElement, scoreValue: HTMLSpanElement, gameOverMenu: HTMLDivElement, perspectiveGrid: HTMLDivElement, cameraModeIndicator: HTMLDivElement, cameraIcon: HTMLDivElement, cameraModeText: HTMLDivElement, controlsHelp: HTMLDivElement, minimapContainer: HTMLDivElement, nextPieceUIContainer: HTMLDivElement, difficultyDisplay: HTMLDivElement, difficultyCube: HTMLDivElement, difficultyValue: HTMLDivElement;
+let startButton: HTMLButtonElement, restartButton: HTMLButtonElement, pauseRestartButton: HTMLButtonElement, mainMenuButton: HTMLButtonElement, resumeButton: HTMLButtonElement, pauseMenuButton: HTMLButtonElement, startMenu: HTMLDivElement, pauseMenu: HTMLDivElement, scoreDisplay: HTMLDivElement, scoreValue: HTMLSpanElement, gameOverMenu: HTMLDivElement, perspectiveGrid: HTMLDivElement, cameraModeIndicator: HTMLDivElement, cameraIcon: HTMLDivElement, cameraModeText: HTMLDivElement, controlsHelp: HTMLDivElement, minimapContainer: HTMLDivElement, nextPieceUIContainer: HTMLDivElement, rotationHintsSvg: SVGSVGElement, difficultyDisplay: HTMLDivElement, difficultyCube: HTMLDivElement, difficultyValue: HTMLDivElement;
 
 // Lock Delay Timer теперь в models/lock-delay-indicator.ts
 
@@ -1503,6 +1503,7 @@ document.addEventListener('DOMContentLoaded', () => {
     controlsHelp = document.getElementById('controls-help') as HTMLDivElement;
     minimapContainer = document.getElementById('minimap-container') as HTMLDivElement;
     nextPieceUIContainer = document.getElementById('next-piece-container') as HTMLDivElement;
+    rotationHintsSvg = document.getElementById('rotation-hints') as unknown as SVGSVGElement;
     difficultyDisplay = document.getElementById('difficulty-display') as HTMLDivElement;
     difficultyCube = document.getElementById('difficulty-cube') as HTMLDivElement;
     difficultyValue = document.getElementById('difficulty-value') as HTMLDivElement;
@@ -1606,6 +1607,9 @@ effect(() => {
     if (nextPieceUIContainer) {
         const shouldShowNextPiece = isPlaying || isPaused;
         nextPieceUIContainer.classList.toggle('hidden', !shouldShowNextPiece);
+        if (rotationHintsSvg) {
+            rotationHintsSvg.classList.toggle('hidden', !shouldShowNextPiece);
+        }
     }
     if (difficultyDisplay) {
         const shouldShowDifficulty = isPlaying || isPaused || isGameOver;

--- a/src/style.css
+++ b/src/style.css
@@ -573,40 +573,36 @@ body {
 }
 
 /* Подсказка вращения клавишами Q/W/E */
-.rotation-hints {
+.rotation-hints-container {
   position: fixed;
   right: 20px;
   bottom: calc(330px + 240px + 10px);
   width: 240px;
   height: 60px;
-  display: block;
   pointer-events: none;
+  z-index: 1000;
 }
-.rotation-hints .hint {
-  transform-origin: 30px 30px;
+
+.rotation-hints-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
-.hint-q {
-  transform: perspective(80px) rotateY(60deg);
-}
-.hint-w {
-  transform: perspective(80px) rotateX(-60deg);
-}
-.hint-e {
-  transform: none;
-}
-.rotation-hints path {
-  stroke: #00ffff;
-  stroke-width: 2;
-  fill: none;
-}
-.rotation-hints text {
-  fill: #00ffff;
+
+.rotation-label {
+  position: absolute;
+  bottom: 4px;
+  color: #00ffff;
   font-family: 'Orbitron', monospace;
   font-weight: 700;
   font-size: 0.9rem;
-  text-anchor: middle;
   text-shadow: 0 0 5px #00ffff;
+  width: 20px;
+  text-align: center;
 }
+.label-q { left: 30px; }
+.label-w { left: 120px; }
+.label-e { right: 30px; }
 
 /* Lock Delay Timer */
 .lock-delay-timer {

--- a/src/style.css
+++ b/src/style.css
@@ -572,6 +572,27 @@ body {
   height: 100%;
 }
 
+/* Подсказка вращения клавишами Q/W/E */
+.rotation-hints {
+  width: 100%;
+  height: 60px;
+  display: block;
+  pointer-events: none;
+}
+.rotation-hints path {
+  stroke: #00ffff;
+  stroke-width: 2;
+  fill: none;
+}
+.rotation-hints text {
+  fill: #00ffff;
+  font-family: 'Orbitron', monospace;
+  font-weight: 700;
+  font-size: 0.9rem;
+  text-anchor: middle;
+  text-shadow: 0 0 5px #00ffff;
+}
+
 /* Lock Delay Timer */
 .lock-delay-timer {
   position: fixed;

--- a/src/style.css
+++ b/src/style.css
@@ -574,10 +574,25 @@ body {
 
 /* Подсказка вращения клавишами Q/W/E */
 .rotation-hints {
-  width: 100%;
+  position: fixed;
+  right: 20px;
+  bottom: calc(330px + 240px + 10px);
+  width: 240px;
   height: 60px;
   display: block;
   pointer-events: none;
+}
+.rotation-hints .hint {
+  transform-origin: 30px 30px;
+}
+.hint-q {
+  transform: perspective(80px) rotateY(60deg);
+}
+.hint-w {
+  transform: perspective(80px) rotateX(-60deg);
+}
+.hint-e {
+  transform: none;
 }
 .rotation-hints path {
   stroke: #00ffff;


### PR DESCRIPTION
## Summary
- display Q/W/E rotation hints above the next piece preview
- style new rotation-hints svg

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a0144873083319e3dfe89ee2fb643